### PR TITLE
Uses object.assign to allow polyfilling of Object.assign.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "js-md5": "^0.3.0",
+    "object.assign": "^4.0.3",
     "promise": "^7.0.4",
     "request": "^2.67.0",
     "underscore": "^1.8.3"

--- a/src/gw2-api.js
+++ b/src/gw2-api.js
@@ -3,6 +3,7 @@ var Promise = require('promise');
 var request = require('request');
 var _ = require('underscore');
 var md5 = require('js-md5');
+var objAssign = require('object.assign').getPolyfill();
 
 /**
  * GW2 API Main interface
@@ -169,7 +170,7 @@ GW2API.prototype = {
         for (var i = 0, len = res.length; i < len; i++) {
           for (var x = 0, xlen = walletCurrencies.length; x < xlen; x++) {
             if (res[i].id == walletCurrencies[x].id) {
-              Object.assign(walletCurrencies[x], res[i]);
+              objAssign(walletCurrencies[x], res[i]);
               break;
             }
           }
@@ -272,7 +273,7 @@ GW2API.prototype = {
     }
 
     if (typeof otherParams === 'object') {
-      Object.assign(params, otherParams);
+      objAssign(params, otherParams);
     }
 
     return this.callAPI(endpoint, params, requiresAuth);


### PR DESCRIPTION
That way it's ES5 compliant even though I'm using Object.assign
